### PR TITLE
Versioning round brackets

### DIFF
--- a/lib/rules/versioning.js
+++ b/lib/rules/versioning.js
@@ -38,14 +38,21 @@ module.exports = exports = function(payload, fn) {
       return fn(null);
 
     // create the value
-    var value = header.value || '';
+    var value           = header.value || '';
+
+    // remove any text between brackets
+    var cleanedValue    = value.replace(/\(.*?\)/gi, '');
 
     // split the values
-    var values = value.split('/');
+    var values          = value.split('/');
 
     // are there more sections
-    if( values.length <= 1 )
+    if( cleanedValue.split('/').length <= 1 ) {
+
+      // skip
       return fn(null);
+
+    }
 
     // add the rule
     payload.addRule({
@@ -59,7 +66,7 @@ module.exports = exports = function(payload, fn) {
       display:        'text',
       header:         'HTTP Header Server should not have versioning',
       message:        'Change $ to $',
-      identifiers:    [ value, values[0] ]
+      identifiers:    [ value, values.slice(0, values.length-1).join('/') ]
     
     });
 

--- a/samples/headers.brackets.json
+++ b/samples/headers.brackets.json
@@ -1,0 +1,44 @@
+{
+  "log": {
+    "entries": [
+      {
+        "request": {},
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Date",
+              "value": "Thu, 15 Oct 2015 16:02:32 GMT"
+            },
+            {
+              "name": "Last-Modified",
+              "value": "Fri, 22 May 2015 13:48:04 GMT"
+            },
+            {
+              "name": "Content-Type",
+              "value": "text/html; charset=utf-8"
+            },
+            {
+              "name": "X-Content-Type-Options",
+              "value": "nosniff"
+            },
+            {
+              "name": "X-XSS-Protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "X-Frame-Options",
+              "value": "DENY"
+            },
+            {
+              "name": "Server",
+              "value": "ECS (ewr/15BD)"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/test/versioning.js
+++ b/test/versioning.js
@@ -116,6 +116,38 @@ describe('versioning', function() {
 
   });
 
+  it('should not set an error if the header contains brackets', function(done) {
+
+    var payload = passmarked.createPayload({
+
+      url: 'http://example.com'
+
+    }, require('../samples/headers.brackets.json'), '<p>test</p>');
+
+    testFunc(payload, function(err) {
+
+      if(err)
+        assert.fail('Error loading rule function');
+
+      var rules = payload.getRules();
+      if(!rules)
+        assert.fail('No rules set with incorrect headers');
+
+      var rule = _.find(rules, function(rule) {
+
+        return rule.key === 'versioning';
+
+      });
+
+      if(rule)
+        assert.fail('No rule was expected as this is a ECS server - ECS (ewr/15BD)');
+
+      done()
+
+    });
+
+  });
+
   it('should not set anything if the header is absent', function(done) {
 
     var payload = passmarked.createPayload({


### PR DESCRIPTION
This is to ignore those small use cases we have seen such as "ECS (ewr/15BD)" from example.com. Most of the pages we hit are serving with the expected format, IE with a / separating the version such as:

```
Server: nginx/1.4.6 (Ubuntu)
```